### PR TITLE
AB#422292 Configure SHIELD CI for stratplotlib

### DIFF
--- a/.sdlcforge.json
+++ b/.sdlcforge.json
@@ -1,0 +1,38 @@
+{
+  "_comment": "SDLC Forge configuration file for stratplotlib",
+  "schema_version": "1.0",
+  "projects": [
+    {
+      "type": "python",
+      "name": "stratplotlib",
+      "path": "",
+      "runtime": {
+        "name": "python",
+        "version": "3.8"
+      },
+      "build_tool": {
+        "name": "pip",
+        "version": "24.0"
+      },
+      "dependency": {
+        "command": "pip install -e ."
+      },
+      "build": {
+        "command": "python setup.py sdist bdist_wheel"
+      },
+      "artefacts": {
+        "source_code": [
+          "stratomap/"
+        ],
+        "deliverable": [
+          "dist/*.whl",
+          "dist/*.tar.gz"
+        ],
+        "dependency_manifests": [
+          "setup.py",
+          "setup.cfg"
+        ]
+      }
+    }
+  ]
+}

--- a/.sdlcforge.json
+++ b/.sdlcforge.json
@@ -8,17 +8,17 @@
       "path": "",
       "runtime": {
         "name": "python",
-        "version": "3.8"
+        "version": "3.13"
       },
       "build_tool": {
-        "name": "pip",
-        "version": "24.0"
+        "name": "setuptools",
+        "version": "3.8"
       },
       "dependency": {
         "command": "pip install -e ."
       },
       "build": {
-        "command": "python setup.py sdist bdist_wheel"
+        "command": "pip install wheel && python setup.py bdist_wheel"
       },
       "artefacts": {
         "source_code": [

--- a/.sdlcforge.json
+++ b/.sdlcforge.json
@@ -18,7 +18,7 @@
         "command": "pip install -e ."
       },
       "build": {
-        "command": "pip install wheel && python setup.py bdist_wheel"
+        "command": "pip install setuptools wheel && python setup.py bdist_wheel"
       },
       "artefacts": {
         "source_code": [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='stratplotlib',
-    packages=['stratplotlib'],
+    packages=['stratomap'],
     version=0.1,
     description='A geospatial visualization library designed for DataFrames',
     author='StratoDem Analytics',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='stratplotlib',


### PR DESCRIPTION
Configure `.sdlcforge.json` for SHIELD CI pipeline.

## Changes
- Add `.sdlcforge.json` with Python 3.13 / setuptools build config
- Fix `setup.py`: wrong package name (`stratplotlib` → `stratomap`, the actual package directory)
- Fix `setup.py`: replace `distutils` with `setuptools` (distutils removed in Python 3.12+)
- Build command installs `setuptools` and `wheel` before invoking `setup.py bdist_wheel`

## CI Results
| Check | Status |
|-------|--------|
| DEPS | ✅ |
| BUILD | ✅ |
| UNIT | ⬜ (no tests) |
| ARCHI | ✅ |
| SBOM | ✅ |
| SAST | ✅ |
| SCA | ❌ (98 Sonatype policy violations — security team review required) |